### PR TITLE
Fix for new Localization() call

### DIFF
--- a/PieceManager.cs
+++ b/PieceManager.cs
@@ -1083,7 +1083,7 @@ public static class LocalizationCache
         {
             return localization;
         }
-
+        var _ = Localization.instance;
         localization = new Localization();
         if (language is not null)
         {


### PR DESCRIPTION
If new Localization() is used before any other mod / game called Localization.instance then it won't call Initialize to set Localization.m_localizationSettings, which leads to NRE